### PR TITLE
Python3 fix

### DIFF
--- a/cliradar.py
+++ b/cliradar.py
@@ -52,7 +52,7 @@ def get_line(start, end):
     ystep = 1 if y1 < y2 else -1
     y = y1
     points = []
-    for x in range(x1, x2 + 1):
+    for x in range(int(x1), int(x2) + 1):
         coord = (y, x) if is_steep else (x, y)
         points.append(coord)
         error -= abs(dy)
@@ -185,9 +185,12 @@ def insert_db(HexID, DateTime, Altitude, Latitude, Longitude):
         SQLQuery = 'SELECT Altitude, LastAltitude FROM data WHERE HexID = \'' + HexID + '\''
         cur.execute(SQLQuery)
         row = cur.fetchone()
-        if row[0] > row[1]: VState = '+'
-        if row[0] < row[1]: VState = '-'
-        if row[0] == row[1]: VState = ' '
+        if row[0] == None or row[1] == None:
+            VState = ' '
+        else:
+            if row[0] > row[1]: VState = '+'
+            if row[0] < row[1]: VState = '-'
+            if row[0] == row[1]: VState = ' '
         #Update
         SQLQuery = 'UPDATE data SET DateTime = \'' + str(DateTime) + '\', LastAltitude = Altitude, Altitude = ' + str(Altitude) + ', LastLongitude = Longitude, LastLatitude = Latitude, Longitude = ' + str(Longitude) + ', Latitude = ' + str(Latitude) + ', Direction = \'' + str(direction) + '\', Distance = \'' + str(distance) + '\', Heading = \'' + str(heading) + '\', HeadingBase = \'' + str(headingBase) + '\', VState = \'' + str(VState) + '\' WHERE HexID = \'' + str(HexID) + '\''
     cur.execute(SQLQuery)
@@ -364,12 +367,12 @@ init_db(cur)
 while True:
     try:
         data = client_socket.recv(1024)
-    except socket.error, e:
+    except socket.error as e:
         err = e.args[0]
         if err == errno.EAGAIN or err == errno.EWOULDBLOCK:
             data = ''
         else:
-            print e
+            print(e)
             sys.exit(1)
     purgeOld()
     os.system('clear')
@@ -381,7 +384,7 @@ while True:
     paintLog()
     doSpin()
     buffer = data
-    spl = buffer.split('\n')
+    spl = str(buffer).split('\n')
     dti = time.strftime('%Y-%m-%d %H:%M:%S')
     for item in spl:
         splitter = item.split(',')

--- a/cliradar.py
+++ b/cliradar.py
@@ -238,8 +238,8 @@ def dist_on_geoid(lat1, lon1, lat2, lon2):
 
 def calculateDistance(startLon, startLat, endLon, endLat):
     try:
-        p1 = Point(str(startLon) + ' ' + str(startLat))
-        p2 = Point(str(endLon) + ' ' +  str(endLat))
+        p1 = Point(longitude=startLon, latitude=startLat)
+        p2 = Point(longitude=endLon, latitude=endLat)
         dist = distance.distance(p1,p2).kilometers
         dist = str(dist)[:5]
         return dist


### PR DESCRIPTION
Fix to make the script compatible with python2 and 3. Works for these versions I have:

```
$ python2 --version
Python 2.7.18 :: Anaconda, Inc.

$ python3 --version
Python 3.9.2

$ conda list | grep -i geopy
geopy                     1.11.0                   py27_0    conda-forge

$ python2 
Python 2.7.18 |Anaconda, Inc.| (default, Jun  4 2021, 14:47:46) 
[GCC 7.3.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import geopy
>>> print geopy.__version__
1.11.0
```

Actually this could be rebased off `master` if you have an older version of geopy. I just built it off the previous PR I made, to fix it for the up-to-date geopy.